### PR TITLE
Revert "nginx v1.15.1"

### DIFF
--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -29,7 +29,7 @@ if [ -z "$CONFIG" ]; then
     exit 1
 fi
 
-mkdir -p "$ARTIFACTS"
+test -d "$ARTIFACTS" || mkdir "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "nginx" %}
-{% set version = "1.15.1" %}
-{% set sha256 = "c7206858d7f832b8ef73a45c9b8f8e436bcb1ee88db2bc85b8e438ecec9d5460" %}
+{% set version = "1.14.0" %}
+{% set sha256 = "5d15becbf69aba1fe33f8d416d97edd95ea8919ea9ac519eff9bafebb6022cb5" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Reverts conda-forge/nginx-feedstock#9

@sodre please confirm if `1.15.1` is indeed a beta. It does not look like it based on the version number!!!